### PR TITLE
Checa links quebrados automaticamente

### DIFF
--- a/.github/workflows/link.yaml
+++ b/.github/workflows/link.yaml
@@ -1,0 +1,30 @@
+name: Link Health
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 10 * * 1"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.8.0
+        with:
+          fail: false
+          debug: false
+          format: markdown
+          output: ./lychee/out.md
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Broken links automated report
+          content-filepath: ./lychee/out.md
+          labels: Bug


### PR DESCRIPTION
Cria um rotinua que, uma vez por semana, vai gerar um relatório de links quebrados (_issue_ no GitHub) existentes nos arquivos markdown do repositório.